### PR TITLE
onclick for file inputs clears the file selection

### DIFF
--- a/src/conversion-form/html/form.html
+++ b/src/conversion-form/html/form.html
@@ -39,7 +39,7 @@
 											<label for="primaryInputFile">SBOL/GenBank/FASTA File
 												<img src="img/question.png" width="10px" title="The main file for conversion" />
 											</label>
-											<input type="file" id="primaryInputFile" name="primaryInputFile" size="10" onchange="mainFileChanged()" />
+											<input type="file" id="primaryInputFile" name="primaryInputFile" size="10" onchange="mainFileChanged()" onclick="this.value=null;" />
 											<p class="help-block" id="primaryFileHelp">
 												Upload an SBOL, GenBank, or FASTA file for conversion.
 											</p>

--- a/src/validation-form/html/form.html
+++ b/src/validation-form/html/form.html
@@ -39,7 +39,7 @@
 											<label for="primaryInputFile">SBOL/GenBank/FASTA File
 												<img src="img/question.png" width="10px" title="The main file for validation/conversion" />
 											</label>
-											<input type="file" id="primaryInputFile" name="primaryInputFile" size="10" onchange="mainFileChanged()" />
+											<input type="file" id="primaryInputFile" name="primaryInputFile" size="10" onchange="mainFileChanged()" onclick="this.value=null;" />
 											<p class="help-block" id="primaryFileHelp">
 												Upload an SBOL, GenBank, or FASTA file for validation/conversion.
 											</p>
@@ -51,7 +51,7 @@
 											<label for="diffInputFile">Comparison file
 												<img src="img/question.png" width="10px" title="The file used for comparison -- must be SBOL" />
 											</label>
-											<input type="file" id="diffInputFile" name="diffInputFile" onchange="diffFileChanged()" />
+											<input type="file" id="diffInputFile" name="diffInputFile" onchange="diffFileChanged()" onclick="this.value=null;" />
 											<p class="help-block" id="diffFileHelp">
 												Upload an SBOL file for comparison.
 											</p>


### PR DESCRIPTION
Fixes #60 such that if a user validates a file, edits the file,
saves the file with the same name, and re-selects the file as
the input, then the second run of the validator will get the
post-edit version of the file.